### PR TITLE
`GET is-room-exit` のバグの修正

### DIFF
--- a/server.go
+++ b/server.go
@@ -21,7 +21,7 @@ type Player struct {
 
 type Theme struct {
 	PlayerId string `json:"playerId"`
-	Text   string `json:"theme"`
+	Text     string `json:"theme"`
 }
 
 type Hint struct {
@@ -37,7 +37,7 @@ func main() {
 	e.Use(middleware.Recover())
 	// ローカル環境の場合、http://localhost:1323/
 	e.GET("/is-room-exit", isRoomExit)
-	e.GET("/partic-list", func(c echo.Context) error {  //TODO関数の管理ときに修正
+	e.GET("/partic-list", func(c echo.Context) error { //TODO関数の管理ときに修正
 		playerList := getParticList(c)
 		return c.JSON(http.StatusOK, playerList)
 	})
@@ -56,11 +56,9 @@ func main() {
 }
 
 func isRoomExit(c echo.Context) error {
-	var exit bool = true
 	roomId := c.QueryParam("roomId")
-	password := c.QueryParam("password")
+	exit := useDB.IsRoomExit(roomId)
 
-	useDB.IsRoomExit(roomId, password)
 	return c.JSON(http.StatusOK, exit)
 }
 
@@ -137,6 +135,7 @@ func postCreateHint(c echo.Context) error {
 	hint := reqBody.Hint
 	return c.JSON(http.StatusOK, useDB.CreateHint(hint, playerId))
 }
+
 // $body = @{
 //     password = "yourpass"
 //     particNum = 3

--- a/src/use_DB/is_room_exit.go
+++ b/src/use_DB/is_room_exit.go
@@ -1,25 +1,17 @@
 package useDB
 
-import (
-	"log"
-)
-
-func IsRoomExit(id string, password string) bool {
+func IsRoomExit(id string) bool {
 	ctx, client := connnectDB()
 	docRef := client.Collection("Room").Doc(id)
 
 	docSnapshot, err := docRef.Get(ctx)
 	if err != nil {
-		log.Fatalf("Failed to get document: %v", err)
+		return false
 	}
 
-	if docSnapshot.Exists() {//TODO ここが必要かの検証
-		data := docSnapshot.Data()
-		value, ok := data["password"]
-		if ok && value == password {
-			return true
-		}
+	if docSnapshot.Exists() { //TODO ここが必要かの検証
+		return true
 	}
+
 	return false
-
 }


### PR DESCRIPTION
## 🔨 変更内容

- `log.Fatalf` の削除 -> roomId が不適の場合に落ちて response が返らないため
- password の削除 -> param に `password: ""` とすると、内部的には `nil` になり、nil vs "" の判定で常に false となったため
- 戻り値を変数にした

## 📸 スクリーンショット

## 📢 この PR に含まないこと

- xxx

## 💡 レビューの観点

### PR 作成者のチェック項目

- [ ] セルフレビュー
- [ ] CI/CD がすべて pass している
- [ ] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー

## ✅ 解決するイシュー

- close #47

## 🤝 関連するイシュー

- #47
